### PR TITLE
remove duplicate prefix

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,6 @@ variable "aws_secret_key" {}
 variable "aws_key_path" {}
 variable "aws_key_name" {}
 variable "aws_openwhisk_ami" {}
-variable "prefix" {}
 
 variable "aws_region" {
   default = "us-east-1"


### PR DESCRIPTION
```shell
admins-MBP-3:openwhisk-setup davidbenko$ terraform plan
module root: 1 error(s) occurred:

* Variable 'prefix': duplicate found. Variable names must be unique.
```